### PR TITLE
Fix/ios11crash

### DIFF
--- a/Sample/iOS/TEditor.Forms.Sample.iOS.csproj
+++ b/Sample/iOS/TEditor.Forms.Sample.iOS.csproj
@@ -19,7 +19,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
     <MtouchProfiling>true</MtouchProfiling>

--- a/iOS/Controls/TEditorViewController.cs
+++ b/iOS/Controls/TEditorViewController.cs
@@ -322,20 +322,27 @@ namespace TEditor
 
 		void KeyboardDidFrame (NSNotification note)
 		{
-			foreach (UIView possibleFormView in _webView.ScrollView.Subviews) {
-				if (possibleFormView.Description.Contains ("UIWebBrowserView")) {
+            int SystemVersion = Convert.ToInt16(UIDevice.CurrentDevice.SystemVersion.Split('.')[0]);
+            if (SystemVersion < 11) {
+				foreach (UIView possibleFormView in _webView.ScrollView.Subviews)
+				{
+					if (possibleFormView.Description.Contains("UIWebBrowserView"))
+					{
 
-					var response = possibleFormView as UIResponder;
-					if (response != null) {
-						var inputAccessoryView = response.InputAccessoryView;
-						if (inputAccessoryView != null) {
-							_keyboardHeight -= inputAccessoryView.Frame.Height;
-							inputAccessoryView.RemoveFromSuperview ();
+						var response = possibleFormView as UIResponder;
+						if (response != null)
+						{
+							var inputAccessoryView = response.InputAccessoryView;
+							if (inputAccessoryView != null)
+							{
+								_keyboardHeight -= inputAccessoryView.Frame.Height;
+								inputAccessoryView.RemoveFromSuperview();
+							}
 						}
+						break;
 					}
-					break;
 				}
-			}
+            }			
 		}
 	}
 }

--- a/iOS/Controls/TEditorViewController.cs
+++ b/iOS/Controls/TEditorViewController.cs
@@ -322,8 +322,8 @@ namespace TEditor
 
 		void KeyboardDidFrame (NSNotification note)
 		{
-            int SystemVersion = Convert.ToInt16(UIDevice.CurrentDevice.SystemVersion.Split('.')[0]);
-            if (SystemVersion < 11) {
+			int SystemVersion = Convert.ToInt16(UIDevice.CurrentDevice.SystemVersion.Split('.')[0]);
+			if (SystemVersion < 11) {
 				foreach (UIView possibleFormView in _webView.ScrollView.Subviews)
 				{
 					if (possibleFormView.Description.Contains("UIWebBrowserView"))
@@ -342,7 +342,7 @@ namespace TEditor
 						break;
 					}
 				}
-            }			
+			}			
 		}
 	}
 }


### PR DESCRIPTION
Resolve #18 

The following line causes the problem
`inputAccessoryView.RemoveFromSuperview();`

So, I made a quick fix which leaves the InputAccessoryView as it is on iOS 11. This prevents applications from crashing (a problem that will keep growing as more people upgrade their phones), and we can investigate alternative solutions for removing InputAccessoryView later.
