### PR TITLE
Added support for automatically focusing the editor

### DIFF
--- a/Droid/Controls/TEditorActivity.cs
+++ b/Droid/Controls/TEditorActivity.cs
@@ -59,6 +59,8 @@ namespace TEditor
             string htmlString = Intent.GetStringExtra("HTMLString") ?? "<p></p>";
             _editorWebView.SetHTML(htmlString);
 
+            bool autoFocusInput = Intent.GetBooleanExtra("AutoFocusInput", false);
+            _editorWebView.SetAutoFocusInput(autoFocusInput);
         }
 
         protected override void Dispose(bool disposing)

--- a/Droid/Controls/TEditorWebView.cs
+++ b/Droid/Controls/TEditorWebView.cs
@@ -46,6 +46,9 @@ namespace TEditor
                 _richTextEditor.InternalHTML = "";
             _richTextEditor.UpdateHTML();
 
+            if (_richTextEditor.AutoFocusInput)
+                _richTextEditor.Focus();
+
             base.OnPageFinished(view, url);
         }
     }
@@ -174,6 +177,10 @@ namespace TEditor
             return await _richTextEditor.GetHTML();
         }
 
+        public void SetAutoFocusInput(bool autoFocusInput)
+        {
+            _richTextEditor.AutoFocusInput = autoFocusInput;
+        }
     }
 }
 

--- a/Droid/TEditorImplementation.cs
+++ b/Droid/TEditorImplementation.cs
@@ -9,7 +9,7 @@ namespace TEditor
     public class TEditorImplementation : BaseTEditor
     {
         public static ToolbarBuilder ToolbarBuilder = null;
-        public override Task<TEditorResponse> ShowTEditor(string html, ToolbarBuilder toolbarBuilder = null)
+        public override Task<TEditorResponse> ShowTEditor(string html, ToolbarBuilder toolbarBuilder = null, bool autoFocusInput = false)
         {
             var result = new TaskCompletionSource<TEditorResponse>();
 
@@ -18,6 +18,7 @@ namespace TEditor
             if (ToolbarBuilder == null)
                 ToolbarBuilder = new ToolbarBuilder().AddAll();
             tActivity.PutExtra("HTMLString", html);
+            tActivity.PutExtra("AutoFocusInput", autoFocusInput);
             tActivity.SetFlags(ActivityFlags.NewTask);
             TEditorActivity.SetOutput = (res, resStr) =>
             {

--- a/Sample/Droid/Properties/AndroidManifest.xml
+++ b/Sample/Droid/Properties/AndroidManifest.xml
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.XAMconsulting.teditor.forms.sample">
 	<uses-sdk android:minSdkVersion="15" />
-	<application android:label="TEditor.Forms.Sample">
-	</application>
+	<application android:label="TEditor.Forms.Sample"></application>
 </manifest>

--- a/Sample/Droid/TEditor.Forms.Sample.Droid.csproj
+++ b/Sample/Droid/TEditor.Forms.Sample.Droid.csproj
@@ -15,7 +15,7 @@
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <AssemblyName>TEditor.Forms.Sample.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/TEditor.Abstractions/BaseTEditor.cs
+++ b/TEditor.Abstractions/BaseTEditor.cs
@@ -5,7 +5,7 @@ namespace TEditor.Abstractions
 {
     public abstract class BaseTEditor : ITEditor, IDisposable
     {
-        public abstract Task<TEditorResponse> ShowTEditor(string html, ToolbarBuilder toolbarBuilder = null);
+        public abstract Task<TEditorResponse> ShowTEditor(string html, ToolbarBuilder toolbarBuilder = null, bool autoFocusInput = false);
 
         /// <summary>
         /// Dispose of class and parent classes

--- a/TEditor.Abstractions/ITEditor.cs
+++ b/TEditor.Abstractions/ITEditor.cs
@@ -5,6 +5,6 @@ namespace TEditor.Abstractions
 {
     public interface ITEditor : IDisposable
     {
-        Task<TEditorResponse> ShowTEditor(string html, ToolbarBuilder toolbarBuilder = null);
+        Task<TEditorResponse> ShowTEditor(string html, ToolbarBuilder toolbarBuilder = null, bool autoFocusInput = false);
     }
 }

--- a/TEditor.Abstractions/TEditor.cs
+++ b/TEditor.Abstractions/TEditor.cs
@@ -11,6 +11,7 @@ namespace TEditor.Abstractions
             EditorLoaded = false;
             FormatHTML = false;
             InternalHTML = string.Empty;
+            AutoFocusInput = false;
         }
 
         public string InternalHTML { get; set; }
@@ -18,6 +19,8 @@ namespace TEditor.Abstractions
         public bool EditorLoaded { get; set; }
 
         public bool FormatHTML { get; set; }
+
+        public bool AutoFocusInput { get; set; }
 
         public string LoadResources()
         {

--- a/TEditor.Abstractions/TEditorAPI.cs
+++ b/TEditor.Abstractions/TEditorAPI.cs
@@ -63,6 +63,12 @@ namespace TEditor.Abstractions
             _javaScriptEvaluatFunc.Invoke(trigger);
         }
 
+        public void Focus()
+        {
+            string trigger = @"zss_editor.focusEditor();";
+            _javaScriptEvaluatFunc.Invoke(trigger);
+        }
+
         public void RemoveFormat()
         {
             string trigger = @"zss_editor.removeFormating();";

--- a/iOS/Controls/TEditorViewController.cs
+++ b/iOS/Controls/TEditorViewController.cs
@@ -33,6 +33,9 @@ namespace TEditor
 			if (string.IsNullOrEmpty (_richTextEditor.InternalHTML))
 				_richTextEditor.InternalHTML = "";
 			_richTextEditor.UpdateHTML ();
+
+            if (_richTextEditor.AutoFocusInput)
+                _richTextEditor.Focus();
 		}
 	}
 
@@ -64,9 +67,7 @@ namespace TEditor
 					});
 					return res;
 				});
-				
 			});
-
 		}
 
 		void StyleWebView ()
@@ -232,6 +233,11 @@ namespace TEditor
 		{
 			return await _richTextEditor.GetHTML ();
 		}
+
+        public void SetAutoFocusInput(bool autoFocusInput)
+        {
+            _richTextEditor.AutoFocusInput = autoFocusInput;
+        }
 
 		public override void ViewDidLoad ()
 		{

--- a/iOS/TEditorImplementation.cs
+++ b/iOS/TEditorImplementation.cs
@@ -7,7 +7,7 @@ namespace TEditor
 {
     public class TEditorImplementation : BaseTEditor
     {
-        public override Task<TEditorResponse> ShowTEditor(string html, ToolbarBuilder toolbarBuilder = null)
+        public override Task<TEditorResponse> ShowTEditor(string html, ToolbarBuilder toolbarBuilder = null, bool autoFocusInput = false)
         {
             TaskCompletionSource<TEditorResponse> taskRes = new TaskCompletionSource<TEditorResponse>();
             var tvc = new TEditorViewController();
@@ -16,6 +16,7 @@ namespace TEditor
                 builder = new ToolbarBuilder().AddAll();
             tvc.BuildToolbar(builder);
             tvc.SetHTML(html);
+            tvc.SetAutoFocusInput(autoFocusInput);
             tvc.Title = CrossTEditor.PageTitle;
 
             UINavigationController nav = null;


### PR DESCRIPTION
This adds a new optional boolean flag that allows to automatically focus the editor when it is displayed.

Usage:
```csharp
// ShowTEditor(string html, ToolbarBuilder toolbarBuilder = null, bool autoFocusInput = false)
ShowTEditor("", null, true)
```

It's worth noting that while this works perfectly on iOS, I couldn't find a way to force the keyboard to appear on Android. It still focuses the editor, but the keyboard doesn't appear, unlike on iOS where it does appear.